### PR TITLE
Add bump fee functionality

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -44,8 +44,8 @@ type Txns interface {
 	// Put a new transaction to the database
 	Put(txn *wire.MsgTx, value, height int, timestamp time.Time) error
 
-	// Fetch a tx, height, and timestamp given it's hash
-	Get(txid chainhash.Hash) (*wire.MsgTx, int32, time.Time, error)
+	// Fetch a raw tx and it's metadata given a hash
+	Get(txid chainhash.Hash) (*wire.MsgTx, Txn, error)
 
 	// Fetch all transactions from the db
 	GetAll() ([]Txn, error)

--- a/eight333.go
+++ b/eight333.go
@@ -158,7 +158,7 @@ func (w *SPVWallet) onGetData(p *peer.Peer, m *wire.MsgGetData) {
 	var sent int32
 	for _, thing := range m.InvList {
 		if thing.Type == wire.InvTypeTx {
-			tx, _, _, err := w.txstore.Txns().Get(thing.Hash)
+			tx, _, err := w.txstore.Txns().Get(thing.Hash)
 			if err != nil {
 				log.Errorf("Error getting tx %s: %s", thing.Hash.String(), err.Error())
 			}

--- a/examples/db/txns.go
+++ b/examples/db/txns.go
@@ -39,22 +39,30 @@ func (t *TxnsDB) Put(txn *wire.MsgTx, value, height int, timestamp time.Time) er
 	return nil
 }
 
-func (t *TxnsDB) Get(txid chainhash.Hash) (*wire.MsgTx, int32, time.Time, error) {
+func (t *TxnsDB) Get(txid chainhash.Hash) (*wire.MsgTx, spvwallet.Txn, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	stmt, err := t.db.Prepare("select tx, height, timestamp from txns where txid=?")
+	stmt, err := t.db.Prepare("select tx, value, height, timestamp from txns where txid=?")
 	defer stmt.Close()
 	var ret []byte
+	var txn spvwallet.Txn
+	var value int
 	var height int
 	var timestamp int
-	err = stmt.QueryRow(txid.String()).Scan(&ret, &height, &timestamp)
+	err = stmt.QueryRow(txid.String()).Scan(&ret, &value, &height, &timestamp)
 	if err != nil {
-		return nil, int32(0), time.Now(), err
+		return nil, txn, err
 	}
 	r := bytes.NewReader(ret)
 	msgTx := wire.NewMsgTx(1)
 	msgTx.BtcDecode(r, 1)
-	return msgTx, int32(height), time.Unix(int64(timestamp), 0), nil
+	txn = spvwallet.Txn{
+		Txid:      msgTx.TxHash().String(),
+		Value:     int64(value),
+		Height:    int32(height),
+		Timestamp: time.Unix(int64(timestamp), 0),
+	}
+	return msgTx, txn, nil
 }
 
 func (t *TxnsDB) GetAll() ([]spvwallet.Txn, error) {

--- a/examples/spvclient.go
+++ b/examples/spvclient.go
@@ -34,7 +34,7 @@ func main() {
 	mnemonic := "salon around sketch ivory analyst vital erosion shift organ hub assault notice"
 
 	// Start up a new node
-	wallet, err := spvwallet.NewSPVWallet(mnemonic, &chaincfg.TestNet3Params, 1000, 60, 40, 20, "", dirPath, database, "OpenBazaar", "", nil, ml)
+	wallet, err := spvwallet.NewSPVWallet(mnemonic, &chaincfg.TestNet3Params, 1000, 20, 40, 60, "", dirPath, database, "OpenBazaar", "", nil, ml)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/schema.go
+++ b/schema.go
@@ -12,6 +12,7 @@ const (
 	PRIOIRTY FeeLevel = 0
 	NORMAL            = 1
 	ECONOMIC          = 2
+	FEE_BUMP          = 3
 )
 
 // The end leaves on the HD wallet have only two possible values. External keys are those given

--- a/txstore.go
+++ b/txstore.go
@@ -305,9 +305,9 @@ func (ts *TxStore) Ingest(tx *wire.MsgTx, height int32) (uint32, error) {
 
 	// If hits is nonzero it's a relevant tx and we should store it
 	if hits > 0 {
-		_, h, timestamp, err := ts.Txns().Get(tx.TxHash())
+		_, txn, err := ts.Txns().Get(tx.TxHash())
 		if err != nil {
-			timestamp = time.Now()
+			txn.Timestamp = time.Now()
 			// Callback on listeners
 			for _, listener := range ts.listeners {
 				listener(cb)
@@ -316,8 +316,8 @@ func (ts *TxStore) Ingest(tx *wire.MsgTx, height int32) (uint32, error) {
 		}
 		// Let's check the height before committing so we don't allow rogue peers to send us a lose
 		// tx that resets our height to zero.
-		if h <= 0 {
-			ts.Txns().Put(tx, int(value), int(height), timestamp)
+		if txn.Height <= 0 {
+			ts.Txns().Put(tx, int(value), int(height), txn.Timestamp)
 		}
 	}
 	return hits, err

--- a/wallet.go
+++ b/wallet.go
@@ -211,15 +211,15 @@ func (w *SPVWallet) Transactions() ([]Txn, error) {
 }
 
 func (w *SPVWallet) GetConfirmations(txid chainhash.Hash) (uint32, error) {
-	_, height, _, err := w.txstore.Txns().Get(txid)
+	_, txn, err := w.txstore.Txns().Get(txid)
 	if err != nil {
 		return 0, err
 	}
-	if height == 0 {
+	if txn.Height == 0 {
 		return 0, nil
 	}
 	chainTip := w.ChainTip()
-	return chainTip - uint32(height), nil
+	return chainTip - uint32(txn.Height), nil
 }
 
 func (w *SPVWallet) checkIfStxoIsConfirmed(utxo Utxo, stxos []Stxo) bool {


### PR DESCRIPTION
Creates an API call to bump the fee of a transaction. At present only child
pays for parent is implemented.