### PR TITLE
Eliminate use of NewExtendedKey; KeyManager now returns btcec.PrivateKey

### DIFF
--- a/keys_test.go
+++ b/keys_test.go
@@ -257,7 +257,7 @@ func TestKeyManager_GetKeyForScript(t *testing.T) {
 	if key == nil {
 		t.Error("Returned key is nil")
 	}
-	testAddr, err := key.Address(&chaincfg.MainNetParams)
+	testAddr, err := Address(key, &chaincfg.MainNetParams)
 	if err != nil {
 		t.Error(err)
 	}
@@ -268,7 +268,7 @@ func TestKeyManager_GetKeyForScript(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	importAddr, err := key.Address(&chaincfg.MainNetParams)
+	importAddr, err := Address(key, &chaincfg.MainNetParams)
 	if err != nil {
 		t.Error(err)
 	}
@@ -284,11 +284,11 @@ func TestKeyManager_GetKeyForScript(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	retECKey, err := retKey.ECPrivKey()
+	/*retECKey, err := retKey.ECPrivKey()
 	if err != nil {
 		t.Error(err)
-	}
-	if !bytes.Equal(retECKey.Serialize(), importKey.Serialize()) {
+	}*/
+	if !bytes.Equal(retKey.Serialize(), importKey.Serialize()) {
 		t.Error("Failed to return imported key")
 	}
 }

--- a/sortsignsend_test.go
+++ b/sortsignsend_test.go
@@ -63,7 +63,7 @@ func Test_gatherCoins(t *testing.T) {
 		if coin.Value() != 10000 {
 			t.Error("Returned incorrect coin value")
 		}
-		addr2, err := key.Address(&chaincfg.TestNet3Params)
+		addr2, err := Address(key, &chaincfg.TestNet3Params)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Problem: you rely on a function in btcutil called NewExtendedKey. You use this function to turn an imported key, which is not really an extended key at all, into a pretend extended key just so that it can be returned by KeyManager.GetKeyForScript. 

Solution: GetKeyForScript now returns btcec.PrivateKey rather than hd.ExtendedKey. Other public methods in KeyManager have also been changed to use btcec.PrivateKey. It turns out you didn't really need ExtendedKeys for anything you were already doing. 