### PR TITLE
Separately keep track of peers which have completed their version exchange.

### DIFF
--- a/eight333.go
+++ b/eight333.go
@@ -245,7 +245,7 @@ func (w *SPVWallet) Rebroadcast() {
 	if len(invMsg.InvList) == 0 { // nothing to broadcast, so don't
 		return
 	}
-	for _, peer := range w.peerManager.ConnectedPeers() {
+	for _, peer := range w.peerManager.ReadyPeers() {
 		peer.QueueMessage(invMsg, nil)
 	}
 }

--- a/sortsignsend.go
+++ b/sortsignsend.go
@@ -38,7 +38,7 @@ func (s *SPVWallet) Broadcast(tx *wire.MsgTx) error {
 	}
 
 	log.Debugf("Broadcasting tx %s to peers", tx.TxHash().String())
-	for _, peer := range s.peerManager.ConnectedPeers() {
+	for _, peer := range s.peerManager.ReadyPeers() {
 		peer.QueueMessage(invMsg, nil)
 		s.updateFilterAndSend(peer)
 	}

--- a/wallet.go
+++ b/wallet.go
@@ -195,7 +195,7 @@ func (w *SPVWallet) Mnemonic() string {
 }
 
 func (w *SPVWallet) ConnectedPeers() []*peer.Peer {
-	return w.peerManager.ConnectedPeers()
+	return w.peerManager.ReadyPeers()
 }
 
 func (w *SPVWallet) CurrentAddress(purpose KeyPurpose) btc.Address {
@@ -356,7 +356,7 @@ func (w *SPVWallet) AddWatchedScript(script []byte) error {
 	err := w.txstore.WatchedScripts().Put(script)
 	w.txstore.PopulateAdrs()
 
-	for _, peer := range w.peerManager.ConnectedPeers() {
+	for _, peer := range w.peerManager.ReadyPeers() {
 		w.updateFilterAndSend(peer)
 	}
 	return err


### PR DESCRIPTION
Fixes issue https://github.com/OpenBazaar/spvwallet/issues/25

If there is a download peer that is disconnected, then spvwallet chooses a different peer from PeerManager.connectedPeers to be the new download peer. However, connectedPeers can include peers that haven't exchanged version messages. That means that spvwallet sends the peer a message too early and the peer disconnects it. 

I have split PeerManager.connectedPeers into openPeers and readyPeers. openPeers is for peers for which we have an open connection but we haven't yet exchanged version messages. readyPeers is for those that have exchanged version messages with us and can be the download peer. 

Also this pr is failing the CI checks right now because the current master branch has tests that fail the CI. 