### PR TITLE
Fix for error '../../api/rpc.go:557:36: cannot use tx.Txid (type stri…

### DIFF
--- a/api/rpc.go
+++ b/api/rpc.go
@@ -554,7 +554,7 @@ func (s *server) WalletNotify(in *pb.Empty, stream pb.API_WalletNotifyServer) er
 			return
 		}
 		resp := &pb.Tx{
-			Txid:      hex.EncodeToString(tx.Txid),
+			Txid:      hex.EncodeToString([]byte(tx.Txid)),
 			Value:     tx.Value,
 			Height:    tx.Height,
 			Timestamp: ts,


### PR DESCRIPTION
…ng) as type []byte in argument to hex.EncodeToString'

