### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -296,7 +296,7 @@ func (b *Blockchain) GetBlockLocator() blockchain.BlockLocator {
 	return blockchain.BlockLocator(ret)
 }
 
-// Returns last header before reorg point
+// GetCommonAncestor returns last header before reorg point
 func (b *Blockchain) GetCommonAncestor(bestHeader, prevBestHeader StoredHeader) (*StoredHeader, error) {
 	var err error
 	rollback := func(parent StoredHeader, n int) (StoredHeader, error) {

--- a/txstore.go
+++ b/txstore.go
@@ -94,7 +94,7 @@ func (ts *TxStore) GimmeFilter() (*bloom.Filter, error) {
 	return f, nil
 }
 
-// GetDoubleSpends takes a transaction and compares it with
+// CheckDoubleSpends takes a transaction and compares it with
 // all transactions in the db.  It returns a slice of all txids in the db
 // which are double spent by the received tx.
 func (ts *TxStore) CheckDoubleSpends(argTx *wire.MsgTx) ([]*chainhash.Hash, error) {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?